### PR TITLE
rt75653: journal reference is not required for HTML form validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
 sourceCompatibility = '1.7'
 group = 'ca.nrc.cadc'
-version = '1006'
+version = '1007'
 
 ext {
     intTest_user_name = 'CADCtest'

--- a/src/main/webapp/js/citation_request.js
+++ b/src/main/webapp/js/citation_request.js
@@ -336,7 +336,7 @@
 
       var inputHtml = '<div class="input-group mb-3 doi-remove-author" id="' + parentElementId + '" >' +
           '<input type="text" class="form-control doi-form doi-form-input"  name="' + elementName +
-          '" id="' + elementId + '" />' +
+          '" placeholder="Author or Group Name" id="' + elementId + '" />' +
           '<div class="input-group-addon doi-form ">' +
           '<button type="button" class="btn btn-default doi-small-button glyphicon glyphicon-minus" id="' + elementName + '" ></button>' +
           '</div></div></div>'

--- a/src/main/webapp/request/index.jsp
+++ b/src/main/webapp/request/index.jsp
@@ -163,7 +163,7 @@
                           <label for="doi_author" class="col-sm-3 control-label" id="doi_first_name_label">First Author</label>
                             <div class="col-sm-6">
                               <input type="text" class="form-control doi-form doi-form-input" id="doi_author" name="firstAuthor"
-                                    tabindex="2" required/>
+                                     placeholder="Author or Group Name" tabindex="2" required/>
                               <div class="doi-display doi-author hidden">
                               </div>
                             </div>
@@ -186,7 +186,7 @@
                           <label for="doi_journal_ref" class="col-sm-3 control-label" id="doi_journal_ref_label">Journal Reference (<i>optional</i>) </label>
                           <div class="col-sm-6">
                             <input type="text" class="form-control doi-form doi-form-input" id="doi_journal_ref" name="journalRef"
-                                   placeholder="Journal  Reference" tabindex="3" required/>
+                                   placeholder="Journal  Reference" tabindex="3"/>
                             <div class="doi-display doi-journal-ref hidden">
                             </div>
                           </div>


### PR DESCRIPTION
It was supposed to be optional, but somehow 'required' snuck into the HTML element so the validation flagged if it was empty. :( 

Also added placeholder back in for Author name as the form looked incomplete without it.