### PR TITLE
rt75664: control modal behaviour in DOI UI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,7 @@ ext {
     docker_image_name = 'mach378.cadc.dao.nrc.ca:5000/citation'
 
     // Change this value to test other locations, such as Production or RC.
-//    intTest_default_web_app_url = 'http://rcapps.canfar.net'
-    intTest_default_web_app_url = 'http://jeevesh.cadc.dao.nrc.ca'
+    intTest_default_web_app_url = 'http://rcapps.canfar.net'
     intTest_default_web_app_endpoint = '/citation'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     docker_image_name = 'mach378.cadc.dao.nrc.ca:5000/citation'
 
     // Change this value to test other locations, such as Production or RC.
-    intTest_default_web_app_url = 'http://rcapps.canfar.net'
+    intTest_default_web_app_url = 'http://rc.canfar.net'
     intTest_default_web_app_endpoint = '/citation'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
 sourceCompatibility = '1.7'
 group = 'ca.nrc.cadc'
-version = '1007'
+version = '1008'
 
 ext {
     intTest_user_name = 'CADCtest'

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -169,15 +169,12 @@
                   <div class="modal-content">
                     <div class="modal-header">
                       <h5 class="modal-title" id="infoModalLongTitle"></h5>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                      </button>
                     </div>
                     <div class="modal-body">
-                      <span class="info-span"></span><span class="spinner-span"></span>
+                      <span class="info-span"></span>
+                      <span class="spinner-span glyphicon glyphicon-refresh fast-right-spinner"></span>
                     </div>
                     <div id="infoThanks" class="modal-footer">
-                      <button type="button" class="btn btn-default" data-dismiss="modal">Thanks</button>
                     </div>
                   </div>
                 </div>

--- a/src/main/webapp/js/citation.js
+++ b/src/main/webapp/js/citation.js
@@ -188,7 +188,7 @@
     function handleDOIDelete(doiSuffix) {
       page.clearAjaxAlert()
       page.setProgressBar('busy')
-      page.setInfoModal('Please wait ', 'Deleting DOI ' + doiSuffix, true)
+      page.setInfoModal('Please wait ', 'Deleting DOI ' + doiSuffix, false, true)
 
       page.prepareCall().then(function(serviceURL) {
         var getUrl = serviceURL + '/' + doiSuffix
@@ -218,7 +218,7 @@
       clearTable()
       page.setProgressBar('busy')
       setTableStatus('Loading...')
-      page.setInfoModal('Please wait ', 'Processing request... (may take up to 10 seconds)', true)
+      page.setInfoModal('Please wait ', 'Fetching current DOI list... (may take up to 10 seconds)', false, true)
 
       page.prepareCall().then(function(serviceURL) {
         $.ajax({

--- a/src/main/webapp/js/citation_request.js
+++ b/src/main/webapp/js/citation_request.js
@@ -69,8 +69,6 @@
           }
         }
       }
-
-
     }
 
 
@@ -88,7 +86,6 @@
       page.subscribe(page, cadc.web.citation.events.onAuthenticated, function (e, data) {
         parseUrl()
       })
-
 
       // Monitor changes in data in form: MINT function is not available
       // if data has been updated.
@@ -300,7 +297,6 @@
       page.setProgressBar('okay')
       $('#doi_additional_authors').empty()
 
-
       // Do this only if explicitly asked
       // If this comes in from clicking the 'Clear' button, the data will be
       // the event itself.
@@ -320,7 +316,6 @@
         $('.doi-form').removeClass('hidden')
       }
     }
-
 
     // Must be 1 to start
     var authorcount = 1
@@ -444,13 +439,14 @@
       var doiSuffix = doiDoc.getDOISuffix()
       if (doiSuffix !== '') {
         urlAddition = '/' + doiSuffix
-        modalMessage += ' Updating Data DOI ' + doiSuffix + '...'
+        modalMessage += 'Updating Data DOI ' + doiSuffix + '...'
       }
       else {
         modalMessage += 'Requesting new Data DOI...'
       }
-      page.setInfoModal('Please wait ', modalMessage, false, false)
+      page.setInfoModal('Please wait ', modalMessage, false, true)
 
+      page.setAjaxCount(2)
       Promise.resolve(page.prepareCall())
           .then(serviceURL =>  postDoiMetadata(serviceURL + urlAddition, multiPartData)
               .then(doiSuffix => getDoiStatus(serviceURL, doiSuffix))
@@ -473,7 +469,7 @@
                 // load metadata into the panel here before resolving promise
                 // Populate javascript object behind form
 
-                hideInfoModal()
+                page.hideInfoModal()
                 page.setProgressBar('okay')
                 var jsonData = page.parseJSONStr(request.responseText)
                 $('#doi_number').val(jsonData.resource.identifier['$'])
@@ -514,6 +510,7 @@
       page.setInfoModal('Please wait ', modalMessage, false, false)
       setFormDisplayState('display')
 
+      page.setAjaxCount(2)
       Promise.resolve(page.prepareCall())
           .then(serviceURL =>  postDoiMetadata(serviceURL + urlAddition, multiPartData)
               .then(doiSuffix => getDoiStatus(serviceURL, doiSuffix)
@@ -553,6 +550,7 @@
                 doiDoc.populateDoc(page.parseJSONStr(request.responseText))
                 // Load metadata into the panel here before resolving promise
                 populateForm()
+                page.hideInfoModal()
                 resolve(request)
               } else {
                 reject(request)
@@ -583,12 +581,12 @@
               if (request.status === 200) {
                 // load metadata into the panel here before resolving promise
                 // Populate javascript object behind form
-                hideInfoModal()
                 page.setProgressBar('okay')
                 var jsonData = page.parseJSONStr(request.responseText)
                 loadMetadata(jsonData)
                 curServiceState = jsonData.doistatus.status['$']
                 setPageState(curServiceState)
+                page.hideInfoModal()
                 resolve(request)
               } else {
                 reject(request)
@@ -604,11 +602,10 @@
       })
     }
 
-
     function handleAjaxError(request) {
-        hideInfoModal()
+        page.hideInfoModal(true)
         page.setProgressBar('error')
-        page.setAjaxFail(page.getRcDisplayText(request))
+        page.setAjaxFail(request)
     }
 
     // ---------------- DELETE ----------------
@@ -638,7 +635,7 @@
             'load',
             function () {
               if (request.status === 200) {
-                hideInfoModal()
+                page.hideInfoModal()
                 page.setProgressBar('okay')
                 handleFormReset(true)
                 page.setAjaxSuccess('DOI Deleted')
@@ -706,13 +703,8 @@
       }
     }
 
-    function hideInfoModal() {
-      $('#info_modal').modal('hide')
-      $('body').removeClass('modal-open')
-      $('.modal-backdrop').remove()
-    }
 
-// The polling function
+  // The polling function
     // TODO: test this after talking about web sockets, etc. as possible other things to use...
     function pollDoiStatus(doiNumber, timeout, interval) {
       // Set a reasonable timeout
@@ -740,7 +732,6 @@
 
       //return new Promise(checkCondition)
     }
-
 
     $.extend(this, {
       init: init

--- a/src/main/webapp/landing/index.jsp
+++ b/src/main/webapp/landing/index.jsp
@@ -161,12 +161,10 @@
                             <div class="modal-content">
                                 <div class="modal-header">
                                     <h5 class="modal-title" id="infoModalLongTitle"></h5>
-                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
                                 </div>
                                 <div class="modal-body">
                                     <span class="info-span"></span>
+                                    <span class="spinner-span glyphicon glyphicon-refresh fast-right-spinner"></span>
                                 </div>
                                 <div id="infoThanks" class="modal-footer">
                                     <button type="button" class="btn btn-default" data-dismiss="modal">Thanks</button>

--- a/src/main/webapp/request/index.jsp
+++ b/src/main/webapp/request/index.jsp
@@ -247,16 +247,13 @@
                   <div class="modal-content">
                     <div class="modal-header">
                       <h5 class="modal-title" id="infoModalLongTitle"></h5>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                      </button>
                     </div>
                     <div class="modal-body">
                       <span class="info-span"></span>
                       <span class="spinner-span glyphicon glyphicon-refresh fast-right-spinner"></span>
                     </div>
                     <div id="infoThanks" class="modal-footer">
-                      <button type="button" class="btn btn-default" data-dismiss="modal">Thanks</button>
+                      <button type="button" class="hidden btn btn-default" data-dismiss="modal">Thanks</button>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
- so they aren't able to be closed when the page is doing what it needs to. 
- Added spinners where missing
- Ensure modals stay up through both ajax calls for pages that have more than one (request and landing page), and that they close correctly in error cases
- Added a modal into the landing page because up to now, it was making 2 ajax requests, but not giving any indication it was doing anything. Luckily it was fast enough to not cause an issue up to this point